### PR TITLE
UVMS-3334 : Mobile terminal channels references should be on item and not index

### DIFF
--- a/app/directive/mobileTerminal/mobileTerminalDetails/mobileTerminalDetails.html
+++ b/app/directive/mobileTerminal/mobileTerminalDetails/mobileTerminalDetails.html
@@ -79,7 +79,7 @@
                             <div ng-repeat="communicationChannel in mobileTerminal.channels">
                                 <div ng-form="channelForm" class="channel-form" ng-class="{'single-channel': !isMultipleChannelsAllowed()}">
                                     <div class="delete-channel" ng-show="!disableForm() && mobileTerminal.channels.length > 1">
-                                        <div class="btn btn-default" ng-click="removeChannel($index)" id="mt-{{listIndex}}-channel-{{$index}}-removeChannel">
+                                        <div class="btn btn-default" ng-click="removeChannel(communicationChannel)" id="mt-{{listIndex}}-channel-{{$index}}-removeChannel">
                                             <i class="fa fa-trash" title="{{'common.remove' | i18n}}"></i>
                                         </div>
                                     </div>
@@ -89,20 +89,20 @@
                                             <input type="text" name="communicationChannel" id="mt-{{listIndex}}-channel-{{$index}}-communicationChannel" class="form-control" ng-model="communicationChannel.name">
                                         </div>
                                         <div class="form-group radio-button">
-                                            <input type="checkbox" name="polling" ng-value="$index" ng-model="communicationChannel.capabilities.POLLABLE" ng-disabled="disableChannels.pollable($index)" id="mt-{{listIndex}}-channel-{{$index}}-checkbox-polling">
-                                            <label for="mt-{{listIndex}}-channel-{{$index}}-checkbox-polling" ng-attr-title="{{getRadioButtonHelpText.pollable($index)}}">
+                                            <input type="checkbox" name="polling" ng-value="$index" ng-model="communicationChannel.capabilities.POLLABLE" ng-disabled="disableChannels.pollable(communicationChannel)" id="mt-{{listIndex}}-channel-{{$index}}-checkbox-polling">
+                                            <label for="mt-{{listIndex}}-channel-{{$index}}-checkbox-polling" ng-attr-title="{{getRadioButtonHelpText.pollable(communicationChannel)}}">
                                                 <span>{{'mobileTerminal.form_inmarsatc_communication_selectedchannel_poll_label' | i18n}}</span>
                                             </label>
                                         </div>
                                         <div class="form-group radio-button">
-                                            <input type="checkbox" name="config" ng-value="$index" ng-model="communicationChannel.capabilities.CONFIGURABLE" ng-disabled="disableChannels.configurable($index)" id="mt-{{listIndex}}-channel-{{$index}}-checkbox-config">
-                                            <label for="mt-{{listIndex}}-channel-{{$index}}-checkbox-config" ng-attr-title="{{getRadioButtonHelpText.configurable($index)}}">
+                                            <input type="checkbox" name="config" ng-value="$index" ng-model="communicationChannel.capabilities.CONFIGURABLE" ng-disabled="disableChannels.configurable(communicationChannel)" id="mt-{{listIndex}}-channel-{{$index}}-checkbox-config">
+                                            <label for="mt-{{listIndex}}-channel-{{$index}}-checkbox-config" ng-attr-title="{{getRadioButtonHelpText.configurable(communicationChannel)}}">
                                                 <span>{{'mobileTerminal.form_inmarsatc_communication_selectedchannel_con_label' | i18n}}</span>
                                             </label>
                                         </div>
                                         <div class="form-group radio-button margin-right">
-                                            <input type="checkbox" name="default" ng-value="$index" ng-model="communicationChannel.capabilities.DEFAULT_REPORTING" ng-disabled="disableChannels.defaultReporting($index)" id="mt-{{listIndex}}-channel-{{$index}}-checkbox-default">
-                                            <label for="mt-{{listIndex}}-channel-{{$index}}-checkbox-default" ng-attr-title="{{getRadioButtonHelpText.defaultReporting($index)}}">
+                                            <input type="checkbox" name="default" ng-value="$index" ng-model="communicationChannel.capabilities.DEFAULT_REPORTING" ng-disabled="disableChannels.defaultReporting(communicationChannel)" id="mt-{{listIndex}}-channel-{{$index}}-checkbox-default">
+                                            <label for="mt-{{listIndex}}-channel-{{$index}}-checkbox-default" ng-attr-title="{{getRadioButtonHelpText.defaultReporting(communicationChannel)}}">
                                                 <span>{{'mobileTerminal.form_inmarsatc_communication_selectedchannel_def_label' | i18n}}</span>
                                             </label>
                                         </div>

--- a/app/directive/mobileTerminal/mobileTerminalDetails/mobileTerminalDetails.js
+++ b/app/directive/mobileTerminal/mobileTerminalDetails/mobileTerminalDetails.js
@@ -359,23 +359,6 @@ angular.module('unionvmsWeb')
             alertService.showErrorMessage(locale.getString('mobileTerminal.unassign_vessel_message_on_error'));
         };
 
-        //Channels - Add a new channel
-        $scope.addNewChannel = function(){
-            var newChannel = $scope.mobileTerminal.addNewChannel();
-            //Set LES for new channel
-            if(angular.isDefined($scope.mobileTerminal.plugin.labelName)){
-                //Set LES_DESCRIPTION if attribute is used for the channel
-                if($scope.getTerminalConfig().channelFields.LES_DESCRIPTION){
-                    newChannel.setLESDescription($scope.mobileTerminal.plugin.labelName);
-                }
-            }
-        };
-
-        //Channels - Remove a channel
-        $scope.removeChannel = function(channelIndex){
-            $scope.mobileTerminal.removeChannel(channelIndex);
-        };
-
         //Open history modal
         $scope.onMobileTerminalHistoryClick = function(){
             MobileTerminalHistoryModal.show($scope.mobileTerminal);
@@ -393,53 +376,72 @@ angular.module('unionvmsWeb')
             }
         };
 
+        //Channels - Add a new channel
+        $scope.addNewChannel = function(){
+            var newChannel = $scope.mobileTerminal.addNewChannel();
+            //Set LES for new channel
+            if(angular.isDefined($scope.mobileTerminal.plugin.labelName)){
+                //Set LES_DESCRIPTION if attribute is used for the channel
+                if($scope.getTerminalConfig().channelFields.LES_DESCRIPTION){
+                    newChannel.setLESDescription($scope.mobileTerminal.plugin.labelName);
+                }
+            }
+        };
+
+        //Channels - Remove a channel
+        $scope.removeChannel = function(communicationChannel){
+           $scope.mobileTerminal.removeChannel($scope.mobileTerminal.channels.indexOf(communicationChannel));
+        };
+
+        //Channels - Get help text
         var disabledMessage = locale.getString('mobileTerminal.form_inmarsatc_communication_disabledchannel_message');
         $scope.getRadioButtonHelpText = {
-            pollable: function(index) {
-                if ($scope.disableChannels.pollable(index)) {
+            pollable: function(communicationChannel) {
+                if ($scope.disableChannels.pollable(communicationChannel)) {
                     return disabledMessage;
                 }
                 return locale.getString('mobileTerminal.form_inmarsatc_communication_selectedchannel_poll_label');
             },
-            configurable: function(index) {
-                if ($scope.disableChannels.configurable(index)) {
+            configurable: function(communicationChannel) {
+                if ($scope.disableChannels.configurable(communicationChannel)) {
                     return disabledMessage;
                 }
                 return locale.getString('mobileTerminal.form_inmarsatc_communication_selectedchannel_con_label');
             },
-            defaultReporting: function(index) {
-                if ($scope.disableChannels.defaultReporting(index)) {
+            defaultReporting: function(communicationChannel) {
+                if ($scope.disableChannels.defaultReporting(communicationChannel)) {
                     return disabledMessage;
                 }
                 return locale.getString('mobileTerminal.form_inmarsatc_communication_selectedchannel_def_label');
             }
         };
 
+        //Channels - Disable channels
         $scope.disableChannels = {
-            pollable: function(index) {
+            pollable: function(communicationChannel) {
                 for (var i = 0; i < $scope.mobileTerminal.channels.length; i++) {
                     if ($scope.mobileTerminal.channels[i].capabilities.POLLABLE === true) {
-                        if (index === i) {
+                        if ($scope.mobileTerminal.channels[i] === communicationChannel) {
                             return false;
                         }
                         return true;
                     }
                 }
             },
-            configurable: function(index) {
+            configurable: function(communicationChannel) {
                 for (var i = 0; i < $scope.mobileTerminal.channels.length; i++) {
                     if ($scope.mobileTerminal.channels[i].capabilities.CONFIGURABLE === true) {
-                        if (index === i) {
+                        if ($scope.mobileTerminal.channels[i] === communicationChannel) {
                             return false;
                         }
                         return true;
                     }
                 }
             },
-            defaultReporting: function(index) {
+            defaultReporting: function(communicationChannel) {
                 for (var i = 0; i < $scope.mobileTerminal.channels.length; i++) {
                     if ($scope.mobileTerminal.channels[i].capabilities.DEFAULT_REPORTING === true) {
-                        if (index === i) {
+                        if ($scope.mobileTerminal.channels[i] === communicationChannel) {
                             return false;
                         } else {
                             return true;


### PR DESCRIPTION
* Mobile terminal channel references should be refereed to item instead of index, for being able to change order