### PR TITLE
UVMS-2626 : Assets list - List sorting should be on the whole list and not just page by page

### DIFF
--- a/app/less/components.less
+++ b/app/less/components.less
@@ -169,3 +169,30 @@ ul.links{
         }
     }
 }
+
+.st-sort {
+    cursor: pointer;
+    position: relative;
+
+    &:after {
+        font: normal normal normal 14px/1 FontAwesome;
+        content: '\f0dc';
+        color: @primaryColor;
+        margin-left: 7px;
+        position: relative;
+    }
+
+    &.st-sort-ascent {
+        &:after {
+            content: '\f0de';
+            top: 3px;
+        }
+    }
+
+    &.st-sort-descent {
+        &:after {
+            content: '\f0dd';
+            top: -3px;
+        }
+    }
+}

--- a/app/partial/vessel/vessel.html
+++ b/app/partial/vessel/vessel.html
@@ -34,14 +34,9 @@ copy of the GNU General Public License along with the IFDM Suite. If not, see <h
                             <button class="btn btn-primary btn-sm addnewassetbtn" ng-click="toggleCreateNewVessel()" type="button" show-if-allowed="manageVessels" id="asset-btn-create"><i class="fa fa-plus"></i>  {{'vessel.new_asset' | i18n}}
                             </button>
                         </div>
-                        <div class="col-md-2 col-md-offset-6 nopaddingright">
-                            <input type="text" class="pull-right form-control" placeholder="Filter" ng-model="currentSearchResults.filter" id="asset-input-filter">
-                        </div>
-
                     </div>
                     <div ng-include="'partial/vessel/vesselList/vesselList.html'"></div>
                 </div>
-                <search-results-pagination page='currentSearchResults.page' total='currentSearchResults.totalNumberOfPages' callback='gotoPage'></search-results-pagination >
             </div>
         </div>
     </div>

--- a/app/partial/vessel/vessel.js
+++ b/app/partial/vessel/vessel.js
@@ -18,7 +18,7 @@ angular.module('unionvmsWeb').controller('VesselCtrl', function($scope, $log, $s
     //Keep track of visibility statuses
     $scope.isVisible = {
         search : true,
-        vesselForm : false, 
+        vesselForm : false,
         notificationCancelSearch : false
     };
 
@@ -122,18 +122,15 @@ angular.module('unionvmsWeb').controller('VesselCtrl', function($scope, $log, $s
         $scope.isVisible.notificationCancelSearch = false;
         $scope.currentSearchResults.updateWithNewResults(vesselListPage);
 
-        if(vesselListPage.totalNumberOfLatestMovements) {
-            $scope.currentSearchResults.sortBy = '-lastMovement.time';
-        }else{
-            $scope.currentSearchResults.sortBy = 'name';
-        }
+        $scope.allCurrentSearchResults = $scope.currentSearchResults.items;
+        $scope.currentSearchResultsByPage = $scope.currentSearchResults.items;
     };
 
     // Handle error from search results (listing vessel)
     var onGetSearchResultsError = function(response){
         $scope.isVisible.notificationCancelSearch = false;
 
-        // Error functions not to be runned if search has been cancelled 
+        // Error functions not to be runned if search has been cancelled
         if (response.status !== -1) {
             $scope.currentSearchResults.removeAllItems();
             $scope.currentSearchResults.setLoading(false);

--- a/app/partial/vessel/vesselList/vesselList.html
+++ b/app/partial/vessel/vesselList/vesselList.html
@@ -9,52 +9,46 @@ the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the impl
 FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
 copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
 -->
-<div class="row" ng-controller="VesselListCtrl">
-    <div search-results-table search="currentSearchResults" class="col-md-12">
-        <table class="searchResults colorOdd truncate-text">
-            <thead>
+<div ng-controller="VesselListCtrl" st-table="currentSearchResultsByPage" st-safe-src="allCurrentSearchResults">
+    <table class="searchResults colorOdd truncate-text">
+        <thead>
+        <tr>
+            <th class="checkboxContainer"><input type="checkbox" ng-checked="isAllChecked()" ng-click="checkAll()" ng-disabled="!currentSearchResults.items.length" id="asset-checkbox-select-all"/></th>
+            <th class="st-sort" st-sort="countryCode" st-skip-natural="true" id="asset-sort-countryCode">{{'vessel.table_header_flag_state' | i18n}}</th>
+            <th class="st-sort" st-sort="externalMarking" st-skip-natural="true" id="asset-sort-externalMarking">{{'vessel.table_header_external_marking' | i18n}}</th>
+            <th class="st-sort" st-sort="name" st-skip-natural="true" id="asset-sort-name">{{'vessel.table_header_name' | i18n}}</th>
+            <th class="st-sort" st-sort="ircs" st-skip-natural="true" id="asset-sort-ircs">{{'vessel.table_header_signal' | i18n}}</th>
+            <th class="st-sort" st-sort="cfr" st-skip-natural="true" id="asset-sort-cfr">{{'vessel.table_header_cfr' | i18n}}</th>
+            <th class="st-sort" st-sort="gearType" st-skip-natural="true" id="asset-sort-gearType">{{'vessel.table_header_gear_type' | i18n}}</th>
+            <th class="st-sort" st-sort="licenseType" st-skip-natural="true" id="asset-sort-licenseType">{{'vessel.table_header_license_type' | i18n}}</th>
+            <th class="st-sort" st-sort="lastMovement.time" st-sort-default="reverse" st-skip-natural="true" id="asset-sort-lastMovement">{{'vessel.table_header_last_report' | i18n}}</th>
+            <th>{{'vessel.table_header_details' | i18n}}</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr ng-repeat="item in currentSearchResultsByPage" ng-class="{archived: !item.active}">
+            <td class="checkboxContainer"><input type="checkbox" ng-checked="isChecked(item)" ng-click="checkItem(item)" id="asset-checkbox-listitem"/></td>
+            <td ng-attr-title="{{item.countryCode}}">{{item.countryCode}}</td>
+            <td ng-attr-title="{{item.externalMarking}}">{{item.externalMarking}}</td>
+            <td ng-attr-title="{{item.name}}">{{item.name}}</td>
+            <td ng-attr-title="{{item.ircs}}">{{item.ircs}}</td>
+            <td ng-attr-title="{{item.cfr}}">{{item.cfr}}</td>
+            <td ng-attr-title="{{item.gearType | vesselGearTypeTranslation}}">{{item.gearType | vesselGearTypeTranslation}}</td>
+            <td ng-attr-title="{{item.licenseType | vesselLicenseTypeTranslation}}">{{item.licenseType | vesselLicenseTypeTranslation}}</td>
+            <td class="link" ng-click="showReport(item.lastMovement.guid)" ng-attr-title="{{item.lastMovement.time | timeAgo}}" id="asset-toggle-lastmovement">{{item.lastMovement.time | timeAgo}}</td>
+            <td>
+                <button class="btn btn-default btn-sm" ng-click="toggleViewVessel(item)" id="asset-toggle-form">
+                    <i class="fa" ng-class="allowedToEditVessel(item) ? 'fa-pencil': 'fa-eye'"></i>
+                </button>
+            </td>
+        </tr>
+        </tbody>
+        <tfoot>
             <tr>
-                <th class="checkboxContainer"><input type="checkbox" ng-checked="isAllChecked()" ng-click="checkAll()" ng-disabled="!currentSearchResults.items.length" input-field-id="asset-checkbox-select-all"/></th>
-
-                <th sortable-table-header by="currentSearchResults.sortBy" reverse="currentSearchResults.sortReverse" order="'countryCode'" input-field-id="asset-sort-countryCode">{{'vessel.table_header_flag_state' | i18n}}</th>
-
-                <th sortable-table-header by="currentSearchResults.sortBy" reverse="currentSearchResults.sortReverse" order="'externalMarking'" input-field-id="asset-sort-externalMarking">{{'vessel.table_header_external_marking' | i18n}}</th>
-
-                <th sortable-table-header by="currentSearchResults.sortBy" reverse="currentSearchResults.sortReverse" order="'name'" input-field-id="asset-sort-name">{{'vessel.table_header_name' | i18n}}</th>
-
-                <th sortable-table-header by="currentSearchResults.sortBy" reverse="currentSearchResults.sortReverse" order="'ircs'" input-field-id="asset-sort-ircs">{{'vessel.table_header_signal' | i18n}}</th>
-
-                <th sortable-table-header by="currentSearchResults.sortBy" reverse="currentSearchResults.sortReverse" order="'cfr'" input-field-id="asset-sort-cfr">{{'vessel.table_header_cfr' | i18n}}</th>
-
-                <th sortable-table-header by="currentSearchResults.sortBy" reverse="currentSearchResults.sortReverse" order="'gearType'" input-field-id="asset-sort-gearType">{{'vessel.table_header_gear_type' | i18n}}</th>
-
-                <th sortable-table-header by="currentSearchResults.sortBy" reverse="currentSearchResults.sortReverse" order="'licenseType'" input-field-id="asset-sort-licenseType">{{'vessel.table_header_license_type' | i18n}}</th>
-
-                <th sortable-table-header by="currentSearchResults.sortBy" reverse="currentSearchResults.sortReverse" order="'-lastMovement.time'" input-field-id="asset-sort-lastMovement">{{'vessel.table_header_last_report' | i18n}}</th>
-
-                <th>{{'vessel.table_header_details' | i18n}}</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr ng-repeat="item in currentSearchResults.items | orderBy:currentSearchResults.sortBy:currentSearchResults.sortReverse | filter:currentSearchResults.filter" ng-class="{archived: !item.active}">
-                <td class="checkboxContainer"><input type="checkbox" ng-checked="isChecked(item)" ng-click="checkItem(item)" id="asset-checkbox-listitem"/></td>
-                <td ng-attr-title="{{item.countryCode}}">{{item.countryCode}}</td>
-                <td ng-attr-title="{{item.externalMarking}}">{{item.externalMarking}}</td>
-                <td ng-attr-title="{{item.name}}">{{item.name}}</td>
-                <td ng-attr-title="{{item.ircs}}">{{item.ircs}}</td>
-                <td ng-attr-title="{{item.cfr}}">{{item.cfr}}</td>
-                <td ng-attr-title="{{item.gearType | vesselGearTypeTranslation}}">{{item.gearType | vesselGearTypeTranslation}}</td>
-                <td ng-attr-title="{{item.licenseType | vesselLicenseTypeTranslation}}">{{item.licenseType | vesselLicenseTypeTranslation}}</td>
-                <td>
-                    <span ng-show="item.lastMovement" class="link" ng-click="showReport(item.lastMovement.guid)" ng-attr-title="{{item.lastMovement.time | timeAgo}}" id="asset-toggle-lastmovement">{{item.lastMovement.time | timeAgo}}</span>
-                </td>
-                <td>
-                    <button class="btn btn-default btn-sm" ng-click="toggleViewVessel(item)" id="asset-toggle-form">
-                        <i class="fa" ng-class="allowedToEditVessel(item) ? 'fa-pencil': 'fa-eye'"></i>
-                    </button>
+                <td colspan="12" class="text-right" ng-show="allCurrentSearchResults.length > itemsByPage">
+                    <div st-pagination st-items-by-page="itemsByPage" st-template="partial/common/reportsPagination/reportsPagination.html"></div>
                 </td>
             </tr>
-            </tbody>
-        </table>
-    </div>
+        </tfoot>
+    </table>
 </div>

--- a/app/partial/vessel/vesselList/vesselList.html
+++ b/app/partial/vessel/vesselList/vesselList.html
@@ -9,46 +9,48 @@ the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the impl
 FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
 copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
 -->
-<div ng-controller="VesselListCtrl" st-table="currentSearchResultsByPage" st-safe-src="allCurrentSearchResults">
-    <table class="searchResults colorOdd truncate-text">
-        <thead>
-        <tr>
-            <th class="checkboxContainer"><input type="checkbox" ng-checked="isAllChecked()" ng-click="checkAll()" ng-disabled="!currentSearchResults.items.length" id="asset-checkbox-select-all"/></th>
-            <th class="st-sort" st-sort="countryCode" st-skip-natural="true" id="asset-sort-countryCode">{{'vessel.table_header_flag_state' | i18n}}</th>
-            <th class="st-sort" st-sort="externalMarking" st-skip-natural="true" id="asset-sort-externalMarking">{{'vessel.table_header_external_marking' | i18n}}</th>
-            <th class="st-sort" st-sort="name" st-skip-natural="true" id="asset-sort-name">{{'vessel.table_header_name' | i18n}}</th>
-            <th class="st-sort" st-sort="ircs" st-skip-natural="true" id="asset-sort-ircs">{{'vessel.table_header_signal' | i18n}}</th>
-            <th class="st-sort" st-sort="cfr" st-skip-natural="true" id="asset-sort-cfr">{{'vessel.table_header_cfr' | i18n}}</th>
-            <th class="st-sort" st-sort="gearType" st-skip-natural="true" id="asset-sort-gearType">{{'vessel.table_header_gear_type' | i18n}}</th>
-            <th class="st-sort" st-sort="licenseType" st-skip-natural="true" id="asset-sort-licenseType">{{'vessel.table_header_license_type' | i18n}}</th>
-            <th class="st-sort" st-sort="lastMovement.time" st-sort-default="reverse" st-skip-natural="true" id="asset-sort-lastMovement">{{'vessel.table_header_last_report' | i18n}}</th>
-            <th>{{'vessel.table_header_details' | i18n}}</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr ng-repeat="item in currentSearchResultsByPage" ng-class="{archived: !item.active}">
-            <td class="checkboxContainer"><input type="checkbox" ng-checked="isChecked(item)" ng-click="checkItem(item)" id="asset-checkbox-listitem"/></td>
-            <td ng-attr-title="{{item.countryCode}}">{{item.countryCode}}</td>
-            <td ng-attr-title="{{item.externalMarking}}">{{item.externalMarking}}</td>
-            <td ng-attr-title="{{item.name}}">{{item.name}}</td>
-            <td ng-attr-title="{{item.ircs}}">{{item.ircs}}</td>
-            <td ng-attr-title="{{item.cfr}}">{{item.cfr}}</td>
-            <td ng-attr-title="{{item.gearType | vesselGearTypeTranslation}}">{{item.gearType | vesselGearTypeTranslation}}</td>
-            <td ng-attr-title="{{item.licenseType | vesselLicenseTypeTranslation}}">{{item.licenseType | vesselLicenseTypeTranslation}}</td>
-            <td class="link" ng-click="showReport(item.lastMovement.guid)" ng-attr-title="{{item.lastMovement.time | timeAgo}}" id="asset-toggle-lastmovement">{{item.lastMovement.time | timeAgo}}</td>
-            <td>
-                <button class="btn btn-default btn-sm" ng-click="toggleViewVessel(item)" id="asset-toggle-form">
-                    <i class="fa" ng-class="allowedToEditVessel(item) ? 'fa-pencil': 'fa-eye'"></i>
-                </button>
-            </td>
-        </tr>
-        </tbody>
-        <tfoot>
+<div class="row" ng-controller="VesselListCtrl" st-table="currentSearchResultsByPage" st-safe-src="allCurrentSearchResults">
+    <div search-results-table search="currentSearchResults" class="col-md-12">
+        <table class="searchResults colorOdd truncate-text">
+            <thead>
             <tr>
-                <td colspan="12" class="text-right" ng-show="allCurrentSearchResults.length > itemsByPage">
-                    <div st-pagination st-items-by-page="itemsByPage" st-template="partial/common/reportsPagination/reportsPagination.html"></div>
-                </td>
+                <th class="checkboxContainer"><input type="checkbox" ng-checked="isAllChecked()" ng-click="checkAll()" ng-disabled="!currentSearchResults.items.length" id="asset-checkbox-select-all"/></th>
+                <th class="st-sort" st-sort="countryCode" st-skip-natural="true" id="asset-sort-countryCode">{{'vessel.table_header_flag_state' | i18n}}</th>
+                <th class="st-sort" st-sort="externalMarking" st-skip-natural="true" id="asset-sort-externalMarking">{{'vessel.table_header_external_marking' | i18n}}</th>
+                <th class="st-sort" st-sort="name" st-skip-natural="true" id="asset-sort-name">{{'vessel.table_header_name' | i18n}}</th>
+                <th class="st-sort" st-sort="ircs" st-skip-natural="true" id="asset-sort-ircs">{{'vessel.table_header_signal' | i18n}}</th>
+                <th class="st-sort" st-sort="cfr" st-skip-natural="true" id="asset-sort-cfr">{{'vessel.table_header_cfr' | i18n}}</th>
+                <th class="st-sort" st-sort="gearType" st-skip-natural="true" id="asset-sort-gearType">{{'vessel.table_header_gear_type' | i18n}}</th>
+                <th class="st-sort" st-sort="licenseType" st-skip-natural="true" id="asset-sort-licenseType">{{'vessel.table_header_license_type' | i18n}}</th>
+                <th class="st-sort" st-sort="lastMovement.time" st-sort-default="reverse" st-skip-natural="true" id="asset-sort-lastMovement">{{'vessel.table_header_last_report' | i18n}}</th>
+                <th>{{'vessel.table_header_details' | i18n}}</th>
             </tr>
-        </tfoot>
-    </table>
+            </thead>
+            <tbody>
+                <tr ng-repeat="item in currentSearchResultsByPage" ng-class="{archived: !item.active}">
+                    <td class="checkboxContainer"><input type="checkbox" ng-checked="isChecked(item)" ng-click="checkItem(item)" id="asset-checkbox-listitem"/></td>
+                    <td ng-attr-title="{{item.countryCode}}">{{item.countryCode}}</td>
+                    <td ng-attr-title="{{item.externalMarking}}">{{item.externalMarking}}</td>
+                    <td ng-attr-title="{{item.name}}">{{item.name}}</td>
+                    <td ng-attr-title="{{item.ircs}}">{{item.ircs}}</td>
+                    <td ng-attr-title="{{item.cfr}}">{{item.cfr}}</td>
+                    <td ng-attr-title="{{item.gearType | vesselGearTypeTranslation}}">{{item.gearType | vesselGearTypeTranslation}}</td>
+                    <td ng-attr-title="{{item.licenseType | vesselLicenseTypeTranslation}}">{{item.licenseType | vesselLicenseTypeTranslation}}</td>
+                    <td class="link" ng-click="showReport(item.lastMovement.guid)" ng-attr-title="{{item.lastMovement.time | timeAgo}}" id="asset-toggle-lastmovement">{{item.lastMovement.time | timeAgo}}</td>
+                    <td>
+                        <button class="btn btn-default btn-sm" ng-click="toggleViewVessel(item)" id="asset-toggle-form">
+                            <i class="fa" ng-class="allowedToEditVessel(item) ? 'fa-pencil': 'fa-eye'"></i>
+                        </button>
+                    </td>
+                </tr>
+            </tbody>
+            <tfoot>
+                <tr>
+                    <td colspan="12" class="text-right" ng-show="allCurrentSearchResults.length > itemsByPage">
+                        <div st-pagination st-items-by-page="itemsByPage" st-template="partial/common/reportsPagination/reportsPagination.html"></div>
+                    </td>
+                </tr>
+            </tfoot>
+        </table>
+    </div>
 </div>

--- a/app/partial/vessel/vesselList/vesselList.js
+++ b/app/partial/vessel/vesselList/vesselList.js
@@ -11,6 +11,9 @@ copy of the GNU General Public License along with the IFDM Suite. If not, see <h
  */
 angular.module('unionvmsWeb').controller('VesselListCtrl',function($scope){
 
+    //Number of items displayed on each page
+    $scope.itemsByPage = 20;
+
     //Handle click on the top "check all" checkbox
     $scope.checkAll = function(){
         if($scope.isAllChecked()){
@@ -60,6 +63,5 @@ angular.module('unionvmsWeb').controller('VesselListCtrl',function($scope){
         });
         return checked;
     };
-
 
 });

--- a/app/service/common/searchService.js
+++ b/app/service/common/searchService.js
@@ -14,6 +14,7 @@ angular.module('unionvmsWeb').factory('searchService',function($q, $log, searchU
     var DEFAULT_ITEMS_PER_PAGE = 20;
 
 	var getListRequest = new GetListRequest(1, DEFAULT_ITEMS_PER_PAGE, true, []),
+        getListRequestAllItems = new GetListRequest(1, 10000000, true, []),
         advancedSearchObject  = {};
 
     //Transform array of string to dict with value true
@@ -304,7 +305,7 @@ angular.module('unionvmsWeb').factory('searchService',function($q, $log, searchU
             var deferred = $q.defer();
             searchUtilsService.modifySpanAndTimeZones(getListRequest.criterias);
             searchUtilsService.replaceCommasWithPoint(getListRequest.criterias);
-			vesselRestService.getVesselList(getListRequest).then(function(vesselPage){
+			vesselRestService.getVesselList(getListRequestAllItems).then(function(vesselPage){
                 //Zero matches?
                 if(vesselPage.getNumberOfItems() === 0){
                     return deferred.resolve(vesselPage);

--- a/app/service/common/searchService.js
+++ b/app/service/common/searchService.js
@@ -11,10 +11,10 @@ copy of the GNU General Public License along with the IFDM Suite. If not, see <h
  */
 angular.module('unionvmsWeb').factory('searchService',function($q, $log, searchUtilsService, GetListRequest, VesselListPage, SearchField, vesselRestService, mobileTerminalRestService, pollingRestService, movementRestService, manualPositionRestService, GetPollableListRequest, SearchResultListPage, auditLogRestService, exchangeRestService, alarmRestService, userService) {
 
-    var DEFAULT_ITEMS_PER_PAGE = 20;
+    var DEFAULT_ITEMS_PER_PAGE = 20,
+        ALL_ITEMS = 10000000;
 
 	var getListRequest = new GetListRequest(1, DEFAULT_ITEMS_PER_PAGE, true, []),
-        getListRequestAllItems = new GetListRequest(1, 10000000, true, []),
         advancedSearchObject  = {};
 
     //Transform array of string to dict with value true
@@ -281,7 +281,7 @@ angular.module('unionvmsWeb').factory('searchService',function($q, $log, searchU
                             });
 
                             if(latestMovements.length > 0) {
-                                vessels.totalNumberOfLatestMovements = latestMovements.length;                
+                                vessels.totalNumberOfLatestMovements = latestMovements.length;
                             }
 
                             deferred.resolve(vessels);
@@ -302,9 +302,12 @@ angular.module('unionvmsWeb').factory('searchService',function($q, $log, searchU
 
         //Do the search for vessels
 		searchVessels : function(){
-            var deferred = $q.defer();
+            var deferred = $q.defer(),
+                getListRequestAllItems = new GetListRequest(1, ALL_ITEMS, false, getListRequest.criterias);
+
             searchUtilsService.modifySpanAndTimeZones(getListRequest.criterias);
             searchUtilsService.replaceCommasWithPoint(getListRequest.criterias);
+
 			vesselRestService.getVesselList(getListRequestAllItems).then(function(vesselPage){
                 //Zero matches?
                 if(vesselPage.getNumberOfItems() === 0){
@@ -631,7 +634,7 @@ angular.module('unionvmsWeb').factory('searchService',function($q, $log, searchU
             //Get vessels first?
             if(vesselCriteria.length > 0){
                 var deferred = $q.defer();
-                var getVesselListRequest = new GetListRequest(1, 10000, vesselSearchIsDynamic, vesselCriteria);
+                var getVesselListRequest = new GetListRequest(1, 10000000, vesselSearchIsDynamic, vesselCriteria);
                 var outerThis = this;
                 //Get the vessels
                 vesselRestService.getAllMatchingVessels(getVesselListRequest).then(


### PR DESCRIPTION
- Asset items within /asset list should be sorted on all items
- Add possibility to get all items in list request to BE
- Add style for sorting arrows within list
- Remove previous pagination used for asset list
- Remove filter function (search to be used instead)
- Add loader and error/empty messages for list view
- Only add new FE sorting to asset page for now, not to affect other list views yet


