### PR TITLE
UVMS-3021 : Global settings does not work for default page alarms

### DIFF
--- a/app/partial/login/start.js
+++ b/app/partial/login/start.js
@@ -52,9 +52,9 @@ angular.module('unionvmsWeb').factory('startPageService',function($log, globalSe
             case 'app.assets':
                 return accessToAssetsAndTerminals;
             case 'app.holdingTable':
-                return checkAccess(unionVMSApplication, 'viewAlarmsHoldingTable');
+                return checkAccess('Rules', 'viewAlarmsHoldingTable');
             case 'app.openTickets':
-                return checkAccess(unionVMSApplication, 'viewAlarmsOpenTickets');
+                return checkAccess('Rules', 'viewAlarmsOpenTickets');
             case 'app.auditLog':
                 return checkAccess('Audit', 'viewAudit');
             case 'app.usm.users':


### PR DESCRIPTION
- If user choose Alarms as default start page within config settings this page should be displayed (if user has access)