### PR TITLE
Improve visualisation of older versions

### DIFF
--- a/app/partial/sales/salesDetails/salesReport/versionsDropdown/versionsDropdown.js
+++ b/app/partial/sales/salesDetails/salesReport/versionsDropdown/versionsDropdown.js
@@ -33,7 +33,7 @@
             vm.dropdownItems = [];
             angular.forEach(reportVersions, function(version) {
                 var dropdownItem = {
-                    text : $filter('i18n')('sales.report_item_type_' + version.type) + " " + version.documentExtId,
+                    text : $filter('i18n')('sales.report_item_type_' + version.type) + " (" + $filter('date')(version.creationDate) + ")",
                     reportExtId: version.reportExtId
                 };
                 vm.dropdownItems.push(dropdownItem);

--- a/app/partial/sales/salesDetails/salesReport/versionsDropdown/versionsDropdown.js
+++ b/app/partial/sales/salesDetails/salesReport/versionsDropdown/versionsDropdown.js
@@ -33,7 +33,7 @@
             vm.dropdownItems = [];
             angular.forEach(reportVersions, function(version) {
                 var dropdownItem = {
-                    text : $filter('i18n')('sales.report_item_type_' + version.type) + " (" + $filter('date')(version.creationDate) + ")",
+                    text : $filter('date')(version.creationDate, 'medium'),
                     reportExtId: version.reportExtId
                 };
                 vm.dropdownItems.push(dropdownItem);


### PR DESCRIPTION
Sales offers the possibility to show all older (corrected) versions of a report. To identify an older version, the document id was used. What we didn't realize is that the document id of a correction can be the same as the original document id. Therefore, we now use the creation date as discriminator between older versions.