### PR TITLE
Asset notes presenting as inserted

### DIFF
--- a/app/partial/vessel/vesselNotes/vesselNotesModal/vesselNotesModal.html
+++ b/app/partial/vessel/vesselNotes/vesselNotesModal/vesselNotesModal.html
@@ -38,7 +38,7 @@
                 
                 <div class="col-md-12 textarea-notes">
                     {{'vessel.notes' | i18n}}:<br>
-                    <span class="lowercase"><b>{{vesselNote.notes | vesselHistoryReplaceEmptyValueWithDash}}</b></span>
+                    <span><b>{{vesselNote.notes | vesselHistoryReplaceEmptyValueWithDash}}</b></span>
                 </div>
 
                 <div class="col-md-12">


### PR DESCRIPTION
In partial\vessel\vesselNotes\vesselNotesModal\vesselNotesModal.html file; `class="lowercase"` is defined for Asset note. Removing this attribute fix the problem.