### PR TITLE
[UNIONVMS-4290] Value of the column "Duration" in the trip

### DIFF
--- a/app/filter/spatial/stHumanizeTime/stHumanizeTime.js
+++ b/app/filter/spatial/stHumanizeTime/stHumanizeTime.js
@@ -1,5 +1,5 @@
 angular.module('unionvmsWeb').filter('stHumanizeTime', function(unitConversionService) {
-	return function(number, type) {
-	    return unitConversionService.duration.timeToHuman(number);
-	};
+    return function(number, type) {
+        return unitConversionService.duration.timeToHuman(number, type);
+    };
 });

--- a/app/partial/activity/tripReportsList/tripReportsList.html
+++ b/app/partial/activity/tripReportsList/tripReportsList.html
@@ -47,7 +47,7 @@
 							<div ng-show="attrVisibility.trips.firstEventTime" ng-if="column === 'firstEventTime'">{{ trip.firstFishingActivityDateTime | stDateUtc }}</div>
 							<div ng-show="attrVisibility.trips.lastEventType" ng-if="column === 'lastEventType'" title="{{trip.lastFishingActivity}}">{{ 'abbreviations.activity_' + trip.lastFishingActivity | i18n }}</div>
 							<div ng-show="attrVisibility.trips.lastEventTime" ng-if="column === 'lastEventTime'">{{ trip.lastFishingActivityDateTime | stDateUtc }}</div>
-							<div ng-show="attrVisibility.trips.duration" ng-if="column === 'duration'">{{ trip.tripDuration  | stHumanizeTime }}</div>
+							<div ng-show="attrVisibility.trips.duration" ng-if="column === 'duration'">{{ trip.tripDuration | stHumanizeTime:'milliseconds' }}</div>
 							<div ng-show="attrVisibility.trips.nCorrections" ng-if="column === 'nCorrections'">{{ trip.noOfCorrections }}</div>
 						</td>
 						<td style="width:80px">

--- a/app/service/spatial/unitConversionService-spec.js
+++ b/app/service/spatial/unitConversionService-spec.js
@@ -9,14 +9,22 @@ the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the impl
 FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
 copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
 */
-describe('unitConversionService', function() {
+describe('The unitConversionService', function() {
+    var sut;
 
-  beforeEach(module('unionvmsWeb'));
+    beforeEach(module('unionvmsWeb'));
 
-  it('should ...', inject(function(unitConversionService) {
+    beforeEach(inject(function(unitConversionService) {
+        sut = unitConversionService;
+    }));
 
-	//expect(unitConversionService.doSomething()).toEqual('something');
+    describe('when converting duration', function() {
+        it('converts a duration to human-readable form, assuming seconds as the default unit', function() {
+            expect(sut.duration.timeToHuman(3665)).toBe('1h 1m 5s');
+        });
 
-  }));
-
+        it('converts a duration to human-readable form, taking into account units in Moment format', function() {
+            expect(sut.duration.timeToHuman(90065000, 'milliseconds')).toBe('1d 1h 1m 5s');
+        });
+    });
 });

--- a/app/service/spatial/unitConversionService.js
+++ b/app/service/spatial/unitConversionService.js
@@ -35,7 +35,7 @@ angular.module('unionvmsWeb').factory('unitConversionService',function($filter, 
 	            if (value !== 0){
 	                value = $filter('number')(speed, decimalPlaces);
 	            }
-	            
+
 	            return value + ' ' + finalUnit;
 	        }
 	    },
@@ -64,19 +64,23 @@ angular.module('unionvmsWeb').factory('unitConversionService',function($filter, 
                 if (value !== 0){
                     value = $filter('number')(distance, decimalPlaces);
                 }
-                
+
                 return value + ' ' + unit;
             }
 	    },
 	    duration: {
-	        timeToHuman: function(time){
-	            var duration = moment.duration(Math.abs(time) * 1000);
-	            
+	        timeToHuman: function(time, type){
+                if (typeof type === 'undefined') {
+                    type = 'seconds';
+                }
+
+                var duration = moment.duration(Math.abs(time), type);
+
 	            var days = Math.floor(duration.asDays());
 	            var hours = Math.floor(duration.asHours()) - (days * 24);
 	            var minutes = Math.floor(duration.asMinutes()) - (days * 24 * 60) - (hours * 60);
 	            var seconds = Math.round(duration.asSeconds()  - (days * 24 * 3600) - (hours * 3600) - (minutes * 60));
-	            
+
 	            var value = '';
 	            if (days !== 0){
 	                value += days + 'd ';
@@ -87,20 +91,20 @@ angular.module('unionvmsWeb').factory('unitConversionService',function($filter, 
 	            if (minutes !== 0){
 	                value += minutes + 'm ';
 	            }
-	            
+
 	            if (seconds !== 0){
 	                value += seconds + 's';
 	            }
-	            
+
 	            if (value === ''){
 	                value = '0s';
 	            }
-	            
-	            return value;
+
+	            return value.trim();
 	        },
 	        humanToTime: function(duration){
 	            var parsedDuration = duration.match(/([0-9]+[dhms]{1})/ig);
-	            
+
 	            var finalDuration = 0;
 	            if (parsedDuration){
 	                for (var i = 0; i < parsedDuration.length; i++){
@@ -110,19 +114,19 @@ angular.module('unionvmsWeb').factory('unitConversionService',function($filter, 
 	                    if (parsedDuration[i].toUpperCase().indexOf('H') !== -1){
 	                        finalDuration += (parseInt(parsedDuration[i]) * 3600);
 	                    }
-	                    
+
 	                    if (parsedDuration[i].toUpperCase().indexOf('M') !== -1){
 	                        finalDuration += (parseInt(parsedDuration[i]) * 60);
 	                    }
-	                    
+
 	                    if (parsedDuration[i].toUpperCase().indexOf('S') !== -1){
 	                        finalDuration += parseInt(parsedDuration[i]);
 	                    }
 	                }
-	                
+
 	                return finalDuration;
 	            }
-	            
+
 	            return undefined;
 	        }
 	    },
@@ -137,7 +141,7 @@ angular.module('unionvmsWeb').factory('unitConversionService',function($filter, 
 	            var displayFormat = this.getDateFormat();
                 var src_format = 'YYYY-MM-DD HH:mm:ss Z';
                 var server_format = 'YYYY-MM-DDTHH:mm:ss';
-                
+
                 if (direction === 'to_server'){
                     if (moment.utc(date, src_format).isValid()){
                         return moment.utc(date, src_format).format(server_format);


### PR DESCRIPTION
The problem here was that a value of milliseconds was treated as being in seconds, resulting in 1000x duration. Solved by specifying time units in `unitConversionService.js#timeToHuman()`, keeping the default to seconds.

[Link to issue](https://webgate.ec.europa.eu/CITnet/jira/browse/UNIONVMS-4290)