### PR TITLE
[UNIONVMS-4136] Display the pagination even if there is only one page of results

### DIFF
--- a/app/directive/common/searchResultsPagination/searchResultsPagination.html
+++ b/app/directive/common/searchResultsPagination/searchResultsPagination.html
@@ -1,4 +1,4 @@
-<div class="searchResultsPaginationContainer" ng-hide="total === 1 || page === 0">
+<div class="searchResultsPaginationContainer">
     <ul class="pagination">
        <li class="disabled page-size" ng-show="showListPage">
            <span>


### PR DESCRIPTION
Display the pagination even if there is only one page of results, because now the user can change the number of results per page. This is a correction of the original PR for [UNIONVMS-4136](https://webgate.ec.europa.eu/CITnet/jira/browse/UNIONVMS-4136), that we discussed in a meeting.