### PR TITLE
Revert "[UNIONVMS-4154] fixed issue with results not being displayed"

### DIFF
--- a/app/partial/exchange/exchangeRestService-spec.js
+++ b/app/partial/exchange/exchangeRestService-spec.js
@@ -77,7 +77,7 @@ describe('exchangeRestService', function() {
                             callback({
                                 code : 200,
                                 data: {
-                                    logs: [
+                                    logList: [
                                         {
                                             id: "1",
                                         },

--- a/app/partial/exchange/exchangeRestService.js
+++ b/app/partial/exchange/exchangeRestService.js
@@ -290,9 +290,9 @@ angular.module('unionvmsWeb')
 
                 var exchangeMessages = [];
 
-                if(angular.isArray(response.data.logs)){
-                    for (var i = 0; i < response.data.logs.length; i++){
-                        exchangeMessages.push(Exchange.fromJson(response.data.logs[i]));
+                if(angular.isArray(response.data.logList)){
+                    for (var i = 0; i < response.data.logList.length; i++){
+                        exchangeMessages.push(Exchange.fromJson(response.data.logList[i]));
                     }
                 }
 
@@ -305,7 +305,8 @@ angular.module('unionvmsWeb')
              function(error){
                 console.log("Error getting exchange messages.", error);
                 deferred.reject(error);
-            });
+            }
+            );
             return deferred.promise;
         };
 


### PR DESCRIPTION
The original commit was meant to fix a discrepancy in the names of the fields of `ListQueryResponse`. Specifically the `private List<ExchangeLogDto> logList` was serialized through `getLogs()` as `logs` in JSON representations of this object. We corrected the discrepancy server-side.

Please merge together with the [backend PR](https://github.com/UnionVMS/UVMS-ExchangeModule-APP/pull/180).